### PR TITLE
Implement bus stop fetch and display

### DIFF
--- a/src/lib/components/DynamicDetailSidebar.svelte
+++ b/src/lib/components/DynamicDetailSidebar.svelte
@@ -360,7 +360,7 @@
 			<BusStopsSection
 				bind:this={busStopsSectionRef}
 				{busStops}
-				landmarkId={data.id ?? ''}
+				landmarkId={String(data.apiId ?? '')}
 				{busStopLocation}
 				bind:editingBusStopId
 				on:add={(e) => dispatch('addBusStop', e.detail)}

--- a/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
+++ b/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
@@ -2,9 +2,10 @@
 	import { createEventDispatcher } from 'svelte';
 	import DeleteConfirmationModal from '../DeleteConfirmationModal.svelte';
 	import CreationForm from '../CreationForm.svelte';
+	import type { FetchBusStopListResponse } from '$lib/services/bus-stop';
 
 	//-- Props --
-	export let busStops: any[] = [];
+	export let busStops: FetchBusStopListResponse = [];
 	export let landmarkId: string = '';
 	export let showAddForm: boolean = false;
 	//-- Bus stop location WKT passed from MapPreview --
@@ -47,9 +48,13 @@
 	}
 
 	//-- Start inline editing --
-	function handleEditClick(bs: { id?: string; name?: string; location?: string }) {
-		editingBusStopId = bs.id ?? null;
-		editableBusStop = { ...bs };
+	function handleEditClick(bs: FetchBusStopListResponse[number]) {
+		editingBusStopId = String(bs.id) ?? null;
+		editableBusStop = {
+			id: String(bs.id),
+			name: bs.name,
+			location: bs.location
+		};
 	}
 
 	//-- Confirm inline edit --
@@ -75,8 +80,11 @@
 	}
 
 	//-- Delete bus stop handlers --
-	function handleDeleteClick(bs: { id?: string; name?: string }) {
-		busStopToDelete = bs;
+	function handleDeleteClick(bs: FetchBusStopListResponse[number]) {
+		busStopToDelete = {
+			id: String(bs.id),
+			name: bs.name
+		};
 		showDeleteModal = true;
 	}
 
@@ -115,7 +123,7 @@
 		{#each filteredBusStops as bs}
 			<div class="section-card busstop-card">
 				<div class="busstop-row">
-					{#if editingBusStopId === bs.id}
+					{#if editingBusStopId === String(bs.id)}
 						<!-- Inline Edit Mode -->
 						<div class="busstop-edit-wrapper">
 							<div class="busstop-edit-form">

--- a/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
+++ b/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
@@ -21,7 +21,7 @@
 	//-- Inline editing state --
 	let editableBusStop: { id?: string; name?: string; location?: string } = {};
 
-	$: filteredBusStops = busStops.filter((bs) => String(bs.landmarkId) === String(landmarkId));
+	$: filteredBusStops = busStops.filter((bs) => String(bs.landmark_id) === String(landmarkId));
 
 	//-- Bus stop form fields --
 	const busStopFields = [

--- a/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
+++ b/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
@@ -175,7 +175,7 @@
 					{:else}
 						<!-- View Mode -->
 						<div class="busstop-info">
-							<div class="busstop-id fw-inter-600">{bs.id}</div>
+							<div class="busstop-id fw-inter-600">BS-{bs.id}</div>
 							<div class="busstop-name fw-inter-600" title={bs.name}>
 								{bs.name || 'Unnamed Stop'}
 							</div>

--- a/src/lib/components/landmark-busstop-components/MapOL.svelte
+++ b/src/lib/components/landmark-busstop-components/MapOL.svelte
@@ -1439,7 +1439,8 @@
 						//-- find parent landmark by id and test containment --
 						const lm = (landmarks || []).find(
 							(l: any) =>
-								(l.id || l._id) === bs.landmarkId || String(l.id || l._id) === String(bs.landmarkId)
+								(l.apiId || l.id || l._id) === bs.landmark_id ||
+								String(l.apiId || l.id || l._id) === String(bs.landmark_id)
 						);
 						if (lm && lm.boundary && pointGeom && pointGeom.getCoordinates) {
 							try {
@@ -1454,11 +1455,12 @@
 								handleError(e, 'testing busstop containment');
 							}
 						}
-						if (inside) {
+						//-- Render bus stop if it's inside the landmark boundary OR if it belongs to this landmark (fallback) --
+						if (inside || lm) {
 							FeatureUtils.setFeatureProperties(pointFeat, {
 								busStopId: bs.id || bs._id || null,
 								name: bs.name || '',
-								landmarkId: bs.landmarkId || null
+								landmarkId: bs.landmark_id || null
 							});
 							busStopsSource.addFeature(pointFeat);
 						}

--- a/src/lib/components/landmark-busstop-components/MapOL.svelte
+++ b/src/lib/components/landmark-busstop-components/MapOL.svelte
@@ -1457,7 +1457,7 @@
 								handleError(e, 'testing busstop containment');
 							}
 						}
-						//-- Render bus stop if it's inside the landmark boundary.
+						//-- Render bus stop if it's inside the landmark boundary. --
 						//-- Only use landmark match as fallback if containment couldn't be computed (e.g., missing/invalid boundary) --
 						if (inside || (lm && !couldTestContainment)) {
 							FeatureUtils.setFeatureProperties(pointFeat, {

--- a/src/lib/components/landmark-busstop-components/MapOL.svelte
+++ b/src/lib/components/landmark-busstop-components/MapOL.svelte
@@ -1436,6 +1436,7 @@
 						if (!pointFeat) continue;
 						const pointGeom: any = pointFeat.getGeometry();
 						let inside = false;
+						let couldTestContainment = false;
 						//-- find parent landmark by id and test containment --
 						const lm = (landmarks || []).find(
 							(l: any) =>
@@ -1450,13 +1451,15 @@
 								});
 								if (poly && typeof poly.intersectsCoordinate === 'function') {
 									inside = poly.intersectsCoordinate(pointGeom.getCoordinates());
+									couldTestContainment = true;
 								}
 							} catch (e) {
 								handleError(e, 'testing busstop containment');
 							}
 						}
-						//-- Render bus stop if it's inside the landmark boundary OR if it belongs to this landmark (fallback) --
-						if (inside || lm) {
+						//-- Render bus stop if it's inside the landmark boundary.
+						//-- Only use landmark match as fallback if containment couldn't be computed (e.g., missing/invalid boundary) --
+						if (inside || (lm && !couldTestContainment)) {
 							FeatureUtils.setFeatureProperties(pointFeat, {
 								busStopId: bs.id || bs._id || null,
 								name: bs.name || '',

--- a/src/lib/components/landmark-busstop-components/MapOL.svelte
+++ b/src/lib/components/landmark-busstop-components/MapOL.svelte
@@ -966,7 +966,9 @@
 						dispatch('pointDrawCleared');
 
 						//-- Show alert with validation message --
-						toast.error(busStopValidation.message || 'Bus stop must be inside the selected landmark.');
+						toast.error(
+							busStopValidation.message || 'Bus stop must be inside the selected landmark.'
+						);
 
 						return;
 					}
@@ -1441,8 +1443,8 @@
 						//-- find parent landmark by id and test containment --
 						const lm = (landmarks || []).find(
 							(l: any) =>
-								(l.apiId || l.id || l._id) === bs.landmark_id ||
-								String(l.apiId || l.id || l._id) === String(bs.landmark_id)
+								(l.apiId ?? l.id ?? l._id) === bs.landmark_id ||
+								String(l.apiId ?? l.id ?? l._id) === String(bs.landmark_id)
 						);
 						if (lm && lm.boundary && pointGeom && pointGeom.getCoordinates) {
 							try {

--- a/src/lib/services/bus-stop.ts
+++ b/src/lib/services/bus-stop.ts
@@ -2,4 +2,20 @@ import { apiFetch } from '$lib/services/fetch-client';
 import type { operations } from '$lib/api/types';
 
 export type FetchBusStopListResponse =
-    operations['fetch_bus_stop_executive_landmark_bus_stop_get']['responses'][200]['content']['application/json'];
+	operations['fetch_bus_stop_executive_landmark_bus_stop_get']['responses'][200]['content']['application/json'];
+
+export async function fetchBusStopByLandmark(
+	landmarkIds: number | number[]
+): Promise<FetchBusStopListResponse> {
+	const params = new URLSearchParams();
+	const idArray = Array.isArray(landmarkIds) ? landmarkIds : [landmarkIds];
+	if (idArray.length > 0) {
+		params.append('landmark_id_list', idArray.join(','));
+	}
+	const query = params.toString();
+	const url = `/landmark/bus_stop${query ? `?${query}` : ''}`;
+
+	const res = await apiFetch<FetchBusStopListResponse>('GET', url);
+	if (!res.ok) throw res;
+	return res.data ?? [];
+}

--- a/src/lib/services/bus-stop.ts
+++ b/src/lib/services/bus-stop.ts
@@ -7,11 +7,12 @@ export type FetchBusStopListResponse =
 export async function fetchBusStopByLandmark(
 	landmarkIds: number | number[]
 ): Promise<FetchBusStopListResponse> {
-	const params = new URLSearchParams();
 	const idArray = Array.isArray(landmarkIds) ? landmarkIds : [landmarkIds];
-	if (idArray.length > 0) {
-		params.append('landmark_id_list', idArray.join(','));
+	if (idArray.length === 0) {
+		return [];
 	}
+	const params = new URLSearchParams();
+	params.append('landmark_id_list', idArray.join(','));
 	const query = params.toString();
 	const url = `/landmark/bus_stop${query ? `?${query}` : ''}`;
 

--- a/src/lib/services/bus-stop.ts
+++ b/src/lib/services/bus-stop.ts
@@ -1,0 +1,5 @@
+import { apiFetch } from '$lib/services/fetch-client';
+import type { operations } from '$lib/api/types';
+
+export type FetchBusStopListResponse =
+    operations['fetch_bus_stop_executive_landmark_bus_stop_get']['responses'][200]['content']['application/json'];

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -28,7 +28,7 @@
 	let selected: Landmark | null = null;
 	let showDetail = false;
 	let detailConfig: DetailConfig | null = null;
-	let detailBusStops: any[] = [];
+	let busStops: any[] = [];
 
 	//-- Open Detail Sidebar --
 	async function openDetail(row: Landmark) {
@@ -38,14 +38,14 @@
 		//-- Fetch bus stops for the selected landmark --
 		if (row.apiId) {
 			try {
-				detailBusStops = await fetchBusStopByLandmark([row.apiId]);
+				busStops = await fetchBusStopByLandmark([row.apiId]);
 			} catch (e) {
 				const message = await handleApiError(e);
 				toast.error(message || 'Failed to fetch bus stops for the selected landmark.');
-				detailBusStops = [];
+				busStops = [];
 			}
 		} else {
-			detailBusStops = [];
+			busStops = [];
 		}
 
 		showDetail = true;
@@ -389,7 +389,7 @@
 						<MapPreview
 							bind:boundary
 							landmarks={mapLandmarks}
-							busStops={detailBusStops}
+							{busStops}
 							bind:selectedLandmarkId
 							autoFitLandmarks={false}
 							on:addLandmark={handleAddLandmark}
@@ -417,7 +417,7 @@
 						data={selected}
 						sectionName="landmark"
 						landmarks={formattedLandmarkData}
-						busStops={detailBusStops}
+						{busStops}
 						on:close={() => (showDetail = false)}
 						onDelete={() => {
 							if (selected) {

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -4,7 +4,6 @@
 	import ListingPageHeader from '$lib/components/ListingPageHeader.svelte';
 	import SearchFilterBar from '$lib/components/SearchFilterBar.svelte';
 	import FloatingAddButton from '$lib/components/FloatingAddButton.svelte';
-	import { busStops } from '$lib/dummy-data';
 	import type { Landmark } from '$lib/types/type';
 	import EmptyData from '$lib/components/EmptyData.svelte';
 	import MapPreview from '$lib/components/landmark-busstop-components/MapPreview.svelte';
@@ -21,6 +20,7 @@
 		LANDMARK_TYPE_VALUE_BY_LABEL
 	} from '$lib/constants';
 	import { fetchLandmarkList } from '$lib/services/landmark';
+	import { fetchBusStopByLandmark } from '$lib/services/bus-stop';
 	import { handleApiError } from '$lib/utils/api-error';
 	import toast from '$lib/utils/toast';
 	import { mapLandmarkTypeToLabel, titleCase } from '$lib/helpers';
@@ -28,11 +28,26 @@
 	let selected: Landmark | null = null;
 	let showDetail = false;
 	let detailConfig: DetailConfig | null = null;
+	let detailBusStops: any[] = [];
 
 	//-- Open Detail Sidebar --
-	function openDetail(row: Landmark) {
+	async function openDetail(row: Landmark) {
 		selected = row;
 		detailConfig = getLandmarkDetailConfig(row);
+
+		//-- Fetch bus stops for the selected landmark --
+		if (row.apiId) {
+			try {
+				detailBusStops = await fetchBusStopByLandmark([row.apiId]);
+				console.log('Fetched bus stops for landmark:', detailBusStops);
+			} catch (e) {
+				console.error('Failed to fetch bus stops for landmark:', e);
+				detailBusStops = [];
+			}
+		} else {
+			detailBusStops = [];
+		}
+
 		showDetail = true;
 	}
 
@@ -295,7 +310,7 @@
 						<MapPreview
 							bind:boundary
 							landmarks={mapLandmarks}
-							{busStops}
+							busStops={[]}
 							bind:selectedLandmarkId
 							autoFitLandmarks={false}
 							on:addLandmark={handleAddLandmark}
@@ -374,7 +389,7 @@
 						<MapPreview
 							bind:boundary
 							landmarks={mapLandmarks}
-							{busStops}
+							busStops={detailBusStops}
 							bind:selectedLandmarkId
 							autoFitLandmarks={false}
 							on:addLandmark={handleAddLandmark}
@@ -402,7 +417,7 @@
 						data={selected}
 						sectionName="landmark"
 						landmarks={formattedLandmarkData}
-						{busStops}
+						busStops={detailBusStops}
 						on:close={() => (showDetail = false)}
 						onDelete={() => {
 							if (selected) {

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -35,24 +35,23 @@
 	async function openDetail(row: Landmark) {
 		selected = row;
 		detailConfig = getLandmarkDetailConfig(row);
-		const currentBusStopRequestId = ++busStopRequestId;
-		busStops = []; //-- Clear stale bus stops immediately --
+		busStops = [];
+		showDetail = true; // ← open immediately
 
-		//-- Fetch bus stops for the selected landmark --
+		const currentBusStopRequestId = ++busStopRequestId;
+
 		if (row.apiId) {
 			try {
 				const fetchedBusStops = await fetchBusStopByLandmark([row.apiId]);
-				if (currentBusStopRequestId !== busStopRequestId) return; //-- discard stale response --
+				if (currentBusStopRequestId !== busStopRequestId) return;
 				busStops = fetchedBusStops;
 			} catch (e) {
-				if (currentBusStopRequestId !== busStopRequestId) return; //-- discard stale error --
+				if (currentBusStopRequestId !== busStopRequestId) return;
 				const message = await handleApiError(e);
-				toast.error(message || 'Failed to fetch bus stops for the selected landmark.');
+				toast.error(message || 'Failed to fetch bus stops.');
 				busStops = [];
 			}
 		}
-
-		showDetail = true;
 	}
 
 	//-- Pagination setup --

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -39,9 +39,9 @@
 		if (row.apiId) {
 			try {
 				detailBusStops = await fetchBusStopByLandmark([row.apiId]);
-				console.log('Fetched bus stops for landmark:', detailBusStops);
 			} catch (e) {
-				console.error('Failed to fetch bus stops for landmark:', e);
+				const message = await handleApiError(e);
+				toast.error(message || 'Failed to fetch bus stops for the selected landmark.');
 				detailBusStops = [];
 			}
 		} else {

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -39,8 +39,7 @@
 		selected = row;
 		detailConfig = getLandmarkDetailConfig(row);
 		busStops = [];
-		showDetail = true; // ← open immediately
-
+		showDetail = true;
 		const currentBusStopRequestId = ++busStopRequestId;
 
 		if (row.apiId) {
@@ -348,7 +347,7 @@
 					<div class="map-overlay-content position-relative">
 						<MapPreview
 							bind:boundary
-							landmarks={mapLandmarks}
+							landmarks={selected ? [selected, ...mapLandmarks] : mapLandmarks}
 							{busStops}
 							bind:selectedLandmarkId
 							autoFitLandmarks={false}
@@ -427,7 +426,7 @@
 					<div class="col-12 col-lg-7">
 						<MapPreview
 							bind:boundary
-							landmarks={mapLandmarks}
+							landmarks={selected ? [selected, ...mapLandmarks] : mapLandmarks}
 							{busStops}
 							bind:selectedLandmarkId
 							autoFitLandmarks={false}

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -42,7 +42,7 @@
 		showDetail = true;
 		const currentBusStopRequestId = ++busStopRequestId;
 
-		if (row.apiId) {
+		if (row.apiId != null) {
 			try {
 				const fetchedBusStops = await fetchBusStopByLandmark([row.apiId]);
 				if (currentBusStopRequestId !== busStopRequestId) return;

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -20,7 +20,7 @@
 		LANDMARK_TYPE_VALUE_BY_LABEL
 	} from '$lib/constants';
 	import { fetchLandmarkList } from '$lib/services/landmark';
-	import { fetchBusStopByLandmark } from '$lib/services/bus-stop';
+	import { fetchBusStopByLandmark, type FetchBusStopListResponse } from '$lib/services/bus-stop';
 	import { handleApiError } from '$lib/utils/api-error';
 	import toast from '$lib/utils/toast';
 	import { mapLandmarkTypeToLabel, titleCase } from '$lib/helpers';
@@ -28,24 +28,28 @@
 	let selected: Landmark | null = null;
 	let showDetail = false;
 	let detailConfig: DetailConfig | null = null;
-	let busStops: any[] = [];
+	let busStops: FetchBusStopListResponse = [];
+	let busStopRequestId = 0;
 
 	//-- Open Detail Sidebar --
 	async function openDetail(row: Landmark) {
 		selected = row;
 		detailConfig = getLandmarkDetailConfig(row);
+		const currentBusStopRequestId = ++busStopRequestId;
+		busStops = []; //-- Clear stale bus stops immediately --
 
 		//-- Fetch bus stops for the selected landmark --
 		if (row.apiId) {
 			try {
-				busStops = await fetchBusStopByLandmark([row.apiId]);
+				const fetchedBusStops = await fetchBusStopByLandmark([row.apiId]);
+				if (currentBusStopRequestId !== busStopRequestId) return; //-- discard stale response --
+				busStops = fetchedBusStops;
 			} catch (e) {
+				if (currentBusStopRequestId !== busStopRequestId) return; //-- discard stale error --
 				const message = await handleApiError(e);
 				toast.error(message || 'Failed to fetch bus stops for the selected landmark.');
 				busStops = [];
 			}
-		} else {
-			busStops = [];
 		}
 
 		showDetail = true;
@@ -310,7 +314,7 @@
 						<MapPreview
 							bind:boundary
 							landmarks={mapLandmarks}
-							busStops={[]}
+							{busStops}
 							bind:selectedLandmarkId
 							autoFitLandmarks={false}
 							on:addLandmark={handleAddLandmark}


### PR DESCRIPTION
### **Summary of Changes**
- Integrated Bus Stop Fetch API for landmarks 
- When a landmark is selected, fetch and display its associated bus stops in the detail page
- Display bus stops on the map within the selected landmark boundary

### **How to Test / Verify**
- Open the landmark listing page
- Select a landmark
- Verify:
     - Associated bus stops are fetched and displayed in the detail section
     - Bus stops are rendered correctly on the map
     - Bus stops appear within the landmark boundary
- Verify error handling for failed API calls

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.  
- [x] I have reviewed my own code for potential issues.   
- [x] I have applied code formatting/linting.     
- [x] I have added or updated tests as needed.    
- [x] I have added or updated documentation/comments where necessary. 


### **Additional Notes (Optional)**
N/A
### **Reviewer Notes**
N/A