### PR TITLE
Implement bus stop delete api

### DIFF
--- a/src/lib/components/DynamicDetailSidebar.svelte
+++ b/src/lib/components/DynamicDetailSidebar.svelte
@@ -48,6 +48,11 @@
 	export let hasBusStopEditPermission: boolean = true;
 	export let hasBusStopDeletePermission: boolean = true;
 
+	type DeleteBusStopHandler = (
+		busStopId: string | number
+	) => boolean | void | Promise<boolean | void>;
+	export let onDeleteBusStop: DeleteBusStopHandler = () => {};
+
 	//-- Normalize date fields to YYYY-MM-DD for <input type="date"> compatibility --
 	//-- Uses local timezone to avoid ±1 day shift that toISOString() (UTC) can cause --
 	function normalizeDateFields(obj: DetailEntity): DetailEntity {
@@ -380,7 +385,7 @@
 				bind:editingBusStopId
 				on:add={(e) => dispatch('addBusStop', e.detail)}
 				on:edit={(e) => dispatch('editBusStop', e.detail)}
-				on:delete={(e) => dispatch('deleteBusStop', e.detail)}
+				{onDeleteBusStop}
 				on:addBusStop={(e) => {
 					dispatch('addBusStop', e.detail);
 					busStopLocation = null;

--- a/src/lib/components/DynamicDetailSidebar.svelte
+++ b/src/lib/components/DynamicDetailSidebar.svelte
@@ -45,6 +45,8 @@
 	export let busStops: any[] = [];
 	export let hasDeletePermission: boolean = true;
 	export let hasUpdatePermission: boolean = true;
+	export let hasBusStopEditPermission: boolean = true;
+	export let hasBusStopDeletePermission: boolean = true;
 
 	//-- Normalize date fields to YYYY-MM-DD for <input type="date"> compatibility --
 	//-- Uses local timezone to avoid ±1 day shift that toISOString() (UTC) can cause --
@@ -383,6 +385,8 @@
 					dispatch('addBusStop', e.detail);
 					busStopLocation = null;
 				}}
+				{hasBusStopEditPermission}
+				{hasBusStopDeletePermission}
 			/>
 		{/if}
 

--- a/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
+++ b/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
@@ -213,6 +213,7 @@
 							<button
 								class="icon-btn edit"
 								class:disabled={!hasBusStopEditPermission}
+								disabled={!hasBusStopEditPermission}
 								aria-label="Edit"
 								aria-disabled={!hasBusStopEditPermission}
 								title={!hasBusStopEditPermission ? disabledUpdateTooltip : undefined}
@@ -224,6 +225,7 @@
 							<button
 								class="icon-btn delete"
 								class:disabled={!hasBusStopDeletePermission}
+								disabled={!hasBusStopDeletePermission}
 								aria-label="Delete"
 								aria-disabled={!hasBusStopDeletePermission}
 								title={!hasBusStopDeletePermission ? disabledDeleteTooltip : undefined}

--- a/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
+++ b/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
@@ -18,11 +18,17 @@
 	export let disabledDeleteTooltip = 'You do not have permission to delete this item.';
 	export let disabledUpdateTooltip = 'You do not have permission to update this item.';
 
+	type DeleteBusStopHandler = (
+		busStopId: string | number
+	) => boolean | void | Promise<boolean | void>;
+	export let onDeleteBusStop: DeleteBusStopHandler = () => {};
+
 	const dispatch = createEventDispatcher();
 	//-- Enable Add Bus Stop button only when a location is selected --
 	$: isButtonEnabled = !!busStopLocation;
 	let showDeleteModal = false;
 	let busStopToDelete: { id?: string; name?: string } | null = null;
+	let isDeleting = false;
 
 	//-- Inline editing state --
 	let editableBusStop: { id?: string; name?: string; location?: string } = {};
@@ -93,12 +99,19 @@
 		showDeleteModal = true;
 	}
 
-	function handleDeleteConfirm() {
-		if (busStopToDelete) {
-			dispatch('delete', busStopToDelete);
+	async function handleDeleteConfirm() {
+		if (!busStopToDelete) return;
+		isDeleting = true;
+		try {
+			const result = await onDeleteBusStop(busStopToDelete.id ?? '');
+			if (result === false) return;
+			showDeleteModal = false;
+			busStopToDelete = null;
+		} catch (e) {
+			console.error(e);
+		} finally {
+			isDeleting = false;
 		}
-		showDeleteModal = false;
-		busStopToDelete = null;
 	}
 
 	function handleDeleteCancel() {
@@ -250,6 +263,7 @@
 		sectionName="bus stop"
 		onConfirm={handleDeleteConfirm}
 		onCancel={handleDeleteCancel}
+		loading={isDeleting}
 	/>
 {/if}
 

--- a/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
+++ b/src/lib/components/landmark-busstop-components/BusStopsSection.svelte
@@ -13,6 +13,11 @@
 	//-- Expose editing bus stop ID to parent for map drag interaction --
 	export let editingBusStopId: string | null = null;
 
+	export let hasBusStopDeletePermission = true;
+	export let hasBusStopEditPermission = true;
+	export let disabledDeleteTooltip = 'You do not have permission to delete this item.';
+	export let disabledUpdateTooltip = 'You do not have permission to update this item.';
+
 	const dispatch = createEventDispatcher();
 	//-- Enable Add Bus Stop button only when a location is selected --
 	$: isButtonEnabled = !!busStopLocation;
@@ -192,12 +197,24 @@
 							{/if}
 						</div>
 						<div class="busstop-actions">
-							<button class="icon-btn edit" aria-label="Edit" on:click={() => handleEditClick(bs)}>
+							<button
+								class="icon-btn edit"
+								class:disabled={!hasBusStopEditPermission}
+								aria-label="Edit"
+								aria-disabled={!hasBusStopEditPermission}
+								title={!hasBusStopEditPermission ? disabledUpdateTooltip : undefined}
+								tabindex={!hasBusStopEditPermission ? -1 : undefined}
+								on:click={() => handleEditClick(bs)}
+							>
 								<i class="bi bi-pencil"></i>
 							</button>
 							<button
 								class="icon-btn delete"
+								class:disabled={!hasBusStopDeletePermission}
 								aria-label="Delete"
+								aria-disabled={!hasBusStopDeletePermission}
+								title={!hasBusStopDeletePermission ? disabledDeleteTooltip : undefined}
+								tabindex={!hasBusStopDeletePermission ? -1 : undefined}
 								on:click={() => handleDeleteClick(bs)}
 							>
 								<i class="bi bi-trash"></i>
@@ -328,10 +345,19 @@
 		background: var(--clear-btn-bg);
 	}
 
-	.icon-btn.delete:hover {
+	.icon-btn.delete:not(.disabled):hover {
 		border-color: var(--delete-btn);
 		color: var(--delete-btn);
 		background: var(--clear-btn-bg);
+	}
+
+	.icon-btn.delete.disabled,
+	.icon-btn.edit.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+		border-color: var(--border) !important;
+		color: var(--text-muted) !important;
+		background: var(--bg-card) !important;
 	}
 
 	.empty-busstops {

--- a/src/lib/services/bus-stop.ts
+++ b/src/lib/services/bus-stop.ts
@@ -4,6 +4,9 @@ import type { operations } from '$lib/api/types';
 export type FetchBusStopListResponse =
 	operations['fetch_bus_stop_executive_landmark_bus_stop_get']['responses'][200]['content']['application/json'];
 
+export type DeleteBusStopResponse = null;
+
+//-- fetch bus stops by landmark id(s) --
 export async function fetchBusStopByLandmark(
 	landmarkIds: number | number[]
 ): Promise<FetchBusStopListResponse> {
@@ -19,4 +22,12 @@ export async function fetchBusStopByLandmark(
 	const res = await apiFetch<FetchBusStopListResponse>('GET', url);
 	if (!res.ok) throw res;
 	return res.data ?? [];
+}
+
+//-- Delete Bus Stop --
+export async function deleteBusStop(id: number): Promise<DeleteBusStopResponse> {
+	const url = `/landmark/bus_stop/${encodeURIComponent(String(id))}`;
+	const res = await apiFetch<DeleteBusStopResponse>('DELETE', url);
+	if (!res.ok) throw res;
+	return res.data ?? null;
 }

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -76,3 +76,8 @@ export function canCreateLandmark(): boolean {
 export function canDeleteLandmark(): boolean {
 	return hasPermission('landmark.delete');
 }
+
+//-- bus stop permissions --
+export function canDeleteBusStop(): boolean {
+	return hasPermission('landmark.bus_stop.delete');
+}

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -26,7 +26,7 @@
 	import toast from '$lib/utils/toast';
 	import { mapLandmarkTypeToLabel, titleCase } from '$lib/helpers';
 	import { landmarkSchema } from '$lib/schemas';
-	import { canCreateLandmark, canDeleteLandmark } from '$lib/utils/permissions';
+	import { canCreateLandmark, canDeleteLandmark, canDeleteBusStop } from '$lib/utils/permissions';
 
 	let selected: Landmark | null = null;
 	let showDetail = false;
@@ -490,6 +490,7 @@
 						onSave={(updated: unknown) => {
 							console.log('Save landmark:', updated);
 						}}
+						hasBusStopDeletePermission={canDeleteBusStop()}
 					/>
 				</div>
 			{/if}

--- a/src/routes/landmark/+page.svelte
+++ b/src/routes/landmark/+page.svelte
@@ -21,7 +21,11 @@
 		LANDMARK_TYPE_VALUE_BY_LABEL
 	} from '$lib/constants';
 	import { fetchLandmarkList, createLandmark, deleteLandmark } from '$lib/services/landmark';
-	import { fetchBusStopByLandmark, type FetchBusStopListResponse } from '$lib/services/bus-stop';
+	import {
+		fetchBusStopByLandmark,
+		type FetchBusStopListResponse,
+		deleteBusStop
+	} from '$lib/services/bus-stop';
 	import { handleApiError } from '$lib/utils/api-error';
 	import toast from '$lib/utils/toast';
 	import { mapLandmarkTypeToLabel, titleCase } from '$lib/helpers';
@@ -300,6 +304,29 @@
 		}
 	}
 
+	//-- Delete bus stop --
+	async function handleDeleteBusStop(busStopId: string | number): Promise<boolean> {
+		if (busStopId == null) {
+			toast.error('Unable to determine bus stop id');
+			return false;
+		}
+		const id = Number(busStopId);
+		if (!Number.isFinite(id) || id <= 0) {
+			toast.error('Unable to determine bus stop id');
+			return false;
+		}
+		try {
+			await deleteBusStop(id);
+			toast.success('Bus stop deleted successfully.');
+			busStops = busStops.filter((bs) => bs.id !== id);
+			return true;
+		} catch (e: any) {
+			const message = await handleApiError(e);
+			toast.error(message || 'Failed to delete bus stop.');
+			return false;
+		}
+	}
+
 	//-- confirm Delete landmark --
 	async function handleDeleteSelectedLandmark() {
 		if (!selected) return false;
@@ -491,6 +518,7 @@
 							console.log('Save landmark:', updated);
 						}}
 						hasBusStopDeletePermission={canDeleteBusStop()}
+						onDeleteBusStop={handleDeleteBusStop}
 					/>
 				</div>
 			{/if}


### PR DESCRIPTION
### **Summary of Changes**
- Implement the bus stop Delete API.
- A user with bus-stop delete permission can delete the landmark.
- A user without delete permission can't access the delete button
### **How to Test / Verify**
- Ensure the user with permission can delete the landmark
- Ensure the user without permission can't access the delete button


### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.  
- [x] I have reviewed my own code for potential issues.   
- [x] I have applied code formatting/linting.     
- [x] I have added or updated tests as needed.    
- [x] I have added or updated documentation/comments where necessary. 


### **Additional Notes (Optional)**
Login credentials:
with permission: username:-admin, password :- password
without permission: username:- guest, password:- password


### **Reviewer Notes**
N/A