### PR TITLE
Fix landmark list fetch limit issue in route detail page

### DIFF
--- a/src/lib/components/service-components/ServiceCreate.svelte
+++ b/src/lib/components/service-components/ServiceCreate.svelte
@@ -248,7 +248,7 @@
 
 			//-- 5. Fetch landmark names --
 			const landmarkIds = sorted.map((rl: any) => Number(rl.landmark_id));
-			const rawLandmarks: any[] = await fetchLandmarkList({ id_list: landmarkIds });
+			const rawLandmarks: any[] = await fetchLandmarkList({ id_list: landmarkIds, limit: 100 });
 			const landmarkMap: LandmarkMap = {};
 			rawLandmarks.forEach((raw: any) => {
 				const apiId = Number(raw.id);

--- a/src/lib/components/service-components/ServiceInfoPanel.svelte
+++ b/src/lib/components/service-components/ServiceInfoPanel.svelte
@@ -340,7 +340,7 @@
 					distanceFromStart: Number(rl.distance_from_start ?? 0)
 				}));
 				const landmarkIds = sorted.map((rl: any) => Number(rl.landmark_id));
-				const rawLandmarks: any[] = await fetchLandmarkList({ id_list: landmarkIds });
+				const rawLandmarks: any[] = await fetchLandmarkList({ id_list: landmarkIds, limit: 100 });
 				landmarkMap = {};
 				rawLandmarks.forEach((raw: any) => {
 					const apiId = Number(raw.id);

--- a/src/routes/company/company-services/detail/+page.svelte
+++ b/src/routes/company/company-services/detail/+page.svelte
@@ -157,7 +157,7 @@
 
 			const landmarkIds = service.route.map((r: any) => r.landmarkId);
 			if (landmarkIds.length > 0) {
-				const rawLandmarks = await fetchLandmarkList({ id_list: landmarkIds });
+				const rawLandmarks = await fetchLandmarkList({ id_list: landmarkIds, limit: 100 });
 				landmarks = rawLandmarks.map(mapLandmark);
 			} else {
 				landmarks = [];

--- a/src/routes/company/company-services/duty/paper-ticket/+page.svelte
+++ b/src/routes/company/company-services/duty/paper-ticket/+page.svelte
@@ -133,7 +133,7 @@
 			const missingPointIds = pointIds.filter((id) => !landmarkNameMap.has(id));
 			if (missingPointIds.length > 0) {
 				try {
-					const lmResult = await fetchLandmarkList({ id_list: missingPointIds });
+					const lmResult = await fetchLandmarkList({ id_list: missingPointIds, limit: 100 });
 					if (currentModalRequestId !== modalRequestId) return;
 					const updated = new Map(landmarkNameMap);
 					for (const lm of lmResult as any[]) {
@@ -214,7 +214,7 @@
 			const missingPointIds = uniquePointIds.filter((id) => !landmarkNameMap.has(id));
 			if (missingPointIds.length > 0) {
 				try {
-					const lmResult = await fetchLandmarkList({ id_list: missingPointIds });
+					const lmResult = await fetchLandmarkList({ id_list: missingPointIds, limit: 100 });
 					if (currentRequestId !== requestId) return;
 					const updated = new Map(landmarkNameMap);
 					for (const lm of lmResult as any[]) {


### PR DESCRIPTION
### **Summary of Changes**

- Route detail page was not displaying all landmarks for routes containing more than the default fetch limit
- Updated landmark list fetch API request to use a limit of 100
- Fixed incomplete landmark rendering in the route detail page

### **How to Test / Verify**

- Open a route containing more than 20 landmarks
- Verify all landmarks are displayed correctly in the route detail page
- Verify landmark loading works without UI issues or missing data

### **Checklist (Self-Review)**
- [x] I have tested the changes locally or in a staging environment.  
- [x] I have reviewed my own code for potential issues.   
- [x] I have applied code formatting/linting.     
- [x] I have added or updated tests as needed.    
- [x] I have added or updated documentation/comments where necessary. 


### **Additional Notes (Optional)**
N/A

### **Reviewer Notes**
N/A